### PR TITLE
calcpy_cli.py: fix deprecation error on threading.current_thread()

### DIFF
--- a/calcpy_cli.py
+++ b/calcpy_cli.py
@@ -67,7 +67,7 @@ def main():
     # TODO: need a better fix
     stdoutproxy_write = prompt_toolkit.patch_stdout.StdoutProxy.write
     def skip_asyncio_thread_write(self, data):
-        if not threading.currentThread().name.startswith('asyncio'):
+        if not threading.current_thread().name.startswith('asyncio'):
             return stdoutproxy_write(self, data)
         return len(data)  # Pretend everything was written.
     prompt_toolkit.patch_stdout.StdoutProxy.write = skip_asyncio_thread_write


### PR DESCRIPTION
Hi again,

Your fix 42f9c166e26df216a94aa110c4477ef41c2a832c causes a deprecation warning:
```
/home/dogeystamp/.local/bin/calcpy/calcpy_cli.py:70: DeprecationWarning: currentThread() is deprecated, use current_thread() instead
```
When vim-mode is activated, this warning is produced every time the prompt is shown.
This patch uses the updated name for the method.

I am using Python 3.11.4.